### PR TITLE
Fixed and updated windows input box and customizable ok and cancel labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 dist
 tsconfig.tsbuildinfo
 desktop.ini
+node_modules
+bun.lockb
+native-prompt-*.tgz

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ prompt (title, body, options)
 >The title you want to display at the top of the window
 ### `body:string`
 >Any helpful text to go inside the message box
-### `options: { defaultText?: string; mask?: boolean }`
+### `options: { defaultText?: string; mask?: boolean; okButtonLabel?: string; cancelButtonLabel?: string }`
 >Any (optional) extra options (see below)
 
 ## Options
@@ -35,6 +35,10 @@ prompt (title, body, options)
 >The text you want to already be in the input box beforehand
 ### `mask?: boolean`
 >Whether you want the box to have a hidden input
+### `okButtonLabel?: string`
+>The label for the "ok" button, it only works on windows and linux and by default in linux it is not set and in windows it is set as "Ok"
+### `cancelButtonLabel?: string`
+>The label for the "cancel" button, it only works on windows and linux and by default in linux it is not set and in windows it is set as "Cancel"
 
 ## Examples
 ### Importing
@@ -77,6 +81,18 @@ prompt("This is a title.", "What would you really like to see next?", { defaultT
         // Log the user in
     } else {
         // The user's entered their username or password incorrect
+    }
+})()
+```
+
+### Ok and Cancel buttons modified example
+```js
+(async () => {
+    const text = await prompt("Your Name", "Write your name.", { okButtonLabel: "Submit", cancelButtonLabel: "Abort" });
+    if (text) {
+        // Do something with the input
+    } else {
+        // The user either clicked cancel or left the space blank
     }
 })()
 ```

--- a/native/linux/default.sh
+++ b/native/linux/default.sh
@@ -1,1 +1,1 @@
-zenity --entry --title="$1" --text="$2" --entry-text="$3" $4
+zenity --entry --title="$1" --text="$2" --entry-text="$3" $4 $5 $6

--- a/native/win32/default.vbs
+++ b/native/win32/default.vbs
@@ -1,2 +1,65 @@
+Option Explicit
+
+Function Base64Encode(sText)
+    Dim oXML, oNode
+
+    Set oXML = CreateObject("Msxml2.DOMDocument.3.0")
+    Set oNode = oXML.CreateElement("base64")
+    oNode.dataType = "bin.base64"
+    oNode.nodeTypedValue = Stream_StringToBinary(sText)
+    Base64Encode = oNode.text
+    Set oNode = Nothing
+    Set oXML = Nothing
+End Function
+
+Function Stream_StringToBinary(Text)
+  Const adTypeText = 2
+  Const adTypeBinary = 1
+
+  'Create Stream object
+  Dim BinaryStream 'As New Stream
+  Set BinaryStream = CreateObject("ADODB.Stream")
+
+  'Specify stream type - we want To save text/string data.
+  BinaryStream.Type = adTypeText
+
+  'Specify charset For the source text (unicode) data.
+  BinaryStream.CharSet = "us-ascii"
+
+  'Open the stream And write text/string data To the object
+  BinaryStream.Open
+  BinaryStream.WriteText Text
+
+  'Change stream type To binary
+  BinaryStream.Position = 0
+  BinaryStream.Type = adTypeBinary
+
+  'Ignore first two bytes - sign of
+  BinaryStream.Position = 0
+
+  'Open the stream And get binary data from the object
+  Stream_StringToBinary = BinaryStream.Read
+
+  Set BinaryStream = Nothing
+End Function
+
+Dim box, i, proccessedText, base64EncodedString
 box = InputBox(Wscript.Arguments.Item(1), Wscript.Arguments.Item(0), Wscript.Arguments.Item(2))
-Wscript.Echo "RETURN" + box
+proccessedText = ""
+
+For i = 1 To Len(box)
+    Dim currentChar, charCode
+    currentChar = Mid(box, i, 1)
+    charCode = Asc(currentChar)
+    
+    ' Check if the current character is a special character (not a printable ASCII character)
+    If charCode < 32 Or charCode > 126 Then
+        proccessedText = proccessedText & "\" & charCode & "\"
+    ElseIf currentChar = "\" Then
+        proccessedText = proccessedText & "/\"
+    Else
+        proccessedText = proccessedText & currentChar
+    End If
+Next
+base64EncodedString = Base64Encode(proccessedText)
+Wscript.Echo "RETURN" & base64EncodedString

--- a/native/win32/moreAcurateInput.ps1
+++ b/native/win32/moreAcurateInput.ps1
@@ -40,7 +40,6 @@ $textbox = New-Object System.Windows.Forms.TextBox;
 $textbox.Text = $args[2];
 $textbox.Location = New-Object System.Drawing.Point(15, 30);
 $textbox.Size = New-Object System.Drawing.Size(255, 20);
-$textbox.PasswordChar = "*";
 $textbox.BorderStyle = [System.Windows.Forms.BorderStyle]::FixedSingle;
 $form.Controls.Add($textbox);
 

--- a/package.json
+++ b/package.json
@@ -16,5 +16,8 @@
     "url": "https://github.com/ssight/native-prompt/issues"
   },
   "homepage": "https://github.com/ssight/native-prompt#readme",
-  "keywords": ["nodejs", "electron", "gui"]
+  "keywords": ["nodejs", "electron", "gui"],
+  "devDependencies": {
+    "@types/node": "^20.12.2"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Create native prompts with Node.js and Electron",
   "main": "dist/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "(rm tsconfig.tsbuildinfo && rm -R dist && tsc && node test) || (del .\\tsconfig.tsbuildinfo && rd /s /q .\\dist && tsc && node test.js) || (tsc && node test.js)"
   },
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,15 +2,25 @@ import checkPlatform from './lib/platform-check';
 import { win32, linux, darwin } from './lib/platforms';
 
 const platform = checkPlatform();
-export = async function (title: string, body: string, options: { defaultText?: string, mask?: boolean } = {}): Promise<string | null> {
+
+type Options = {
+    defaultText?: string,
+    mask?: boolean,
+    okButtonLabel?: string,
+    cancelButtonLabel?: string
+}
+
+export = async function (title: string, body: string, options: Options = {}): Promise<string | null> {
     const defaultText: string = options.defaultText || "";
+    const okButtonLabel = options.okButtonLabel || null;
+    const cancelButtonLabel = options.cancelButtonLabel || null;
     
     switch (platform) {
         case 'win32': {
-            if (options.mask) return await win32.displayMask(title, body, defaultText);
+            if (options.mask) return await win32.displayMask(title, body, defaultText, okButtonLabel, cancelButtonLabel);
             else return await win32.displayBox(title, body, defaultText);
         }
-        case 'linux': return await linux(title, body, options.mask, defaultText);
+        case 'linux': return await linux(title, body, options.mask, defaultText, okButtonLabel, cancelButtonLabel);
         case 'darwin': return await darwin(title, body, options.mask, defaultText);
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ export = async function (title: string, body: string, options: Options = {}): Pr
     switch (platform) {
         case 'win32': {
             if (options.mask) return await win32.displayMask(title, body, defaultText, okButtonLabel, cancelButtonLabel);
-            else return await win32.displayBox(title, body, defaultText);
+            else return await win32.displayBox(title, body, defaultText, okButtonLabel, cancelButtonLabel);
         }
         case 'linux': return await linux(title, body, options.mask, defaultText, okButtonLabel, cancelButtonLabel);
         case 'darwin': return await darwin(title, body, options.mask, defaultText);

--- a/src/lib/platforms/linux.ts
+++ b/src/lib/platforms/linux.ts
@@ -1,9 +1,11 @@
 import { spawn } from 'child_process';
 import { resolve as path } from 'path';
 
-export = function (title: string, body: string, mask: boolean, defaultText: string = ""): Promise<string | null> {
+export = function (title: string, body: string, mask: boolean, defaultText: string = "", okButtonLabel?: string, cancelButtonLabel?: string): Promise<string | null> {
     return new Promise(resolve => {
-        const boxSpawner = spawn("bash", [path(__dirname, "../../../", "./native/linux/default.sh").replace("app.asar", "app.asar.unpacked"), title, body, defaultText, mask === true ? "--hide-text" : ""]);
+        const inDist = __dirname.endsWith("dist") || __dirname.endsWith("dist/") || __dirname.endsWith("dist\\");
+        const rootPath = path(__dirname, inDist ? "../" : '../../../');
+        const boxSpawner = spawn("bash", [path(rootPath, "./native/linux/default.sh").replace("app.asar", "app.asar.unpacked"), title, body, defaultText, mask === true ? "--hide-text" : "", okButtonLabel ? "--ok-label=\"" + okButtonLabel + "\"" : "", cancelButtonLabel ? "--cancel-label=\"" + cancelButtonLabel + "\"" : ""]);
 
         boxSpawner.stdout.on('data', d => {
             const data = d.toString() as string;

--- a/src/lib/platforms/win32.ts
+++ b/src/lib/platforms/win32.ts
@@ -1,26 +1,126 @@
 import { spawn } from 'child_process';
 import { resolve as path } from 'path';
 
+/*
 export function displayBox(title: string, body: string, defaultText: string = ""): Promise<string | null> {
     return new Promise(resolve => {
-        const boxSpawner = spawn("cscript", [path(__dirname, '../../../', 'native/win32/default.vbs').replace("app.asar", "app.asar.unpacked"), title, body, defaultText]);
+        const inDist = __dirname.endsWith("dist") || __dirname.endsWith("dist/") || __dirname.endsWith("dist\\");
+        const rootPath = path(__dirname, inDist ? "../" : '../../../');
+        const boxSpawner = spawn("cscript", [path(rootPath, 'native/win32/default.vbs').replace("app.asar", "app.asar.unpacked"), title, body, defaultText]);
 
         boxSpawner.stdout.on('data', (d: string) => {
-            const data = d.toString();
-            if (data.startsWith("RETURN")) resolve(data.replace("RETURN", "").trim() || null);
+            let data = d.toString();
+            if(data.startsWith("RETURN")) data = data.slice("RETURN".length);
+            if(data.startsWith("Microsoft")) return;
+            data = atob(data);
+            data = data.trim();
+            let unproccessedText = "";
+            for(let i = 0;i < data.length;i++) {
+                const currentChar = data.charAt(i);
+                if(currentChar === "/" && data.charAt(i + 1) === "\\") {
+                    unproccessedText += "\\";
+                    i++;
+                }
+                else if(currentChar === "\\") {
+                    const charCodeEnd = data.indexOf("\\", i + 1);
+                    if(charCodeEnd === -1) {
+                        unproccessedText += "\\";
+                        continue;
+                    }
+                    const charCode = parseInt(data.slice(i + 1, charCodeEnd));
+                    if(Number.isNaN(charCode)) {
+                        unproccessedText += "\\";
+                        continue;
+                    }
+                    unproccessedText += String.fromCharCode(charCode);
+                    i = charCodeEnd;
+                }
+                else unproccessedText += currentChar;
+            }
+            resolve(unproccessedText || null);
+        })
+
+        boxSpawner.on('exit', () => resolve(null));
+    })
+}
+*/
+
+export function displayBox(title: string, body: string, defaultText: string = "", okButtonLabel: string = "Ok", cancelButtonLabel: string = "Cancel"): Promise<string | null> {
+    return new Promise(resolve => {
+        const inDist = __dirname.endsWith("dist") || __dirname.endsWith("dist/") || __dirname.endsWith("dist\\");
+        const rootPath = path(__dirname, inDist ? "../" : '../../../');
+        const boxSpawner = spawn("powershell", ["-ExecutionPolicy", "Bypass", "-File", path(rootPath, 'native/win32/moreAcurateInput.ps1').replace("app.asar", "app.asar.unpacked"), title, body, defaultText, okButtonLabel || "Ok", cancelButtonLabel || "Cancel"]);
+
+        boxSpawner.stdout.on('data', (d: string) => {
+            let data = d.toString();
+            if(!data.startsWith("RETURN")) return;
+            data = data.slice("RETURN".length);
+            data = data.trim();
+            let unproccessedText = "";
+            for(let i = 0;i < data.length;i++) {
+                const currentChar = data.charAt(i);
+                if(currentChar === "/" && data.charAt(i + 1) === "\\") {
+                    unproccessedText += "\\";
+                    i++;
+                }
+                else if(currentChar === "\\") {
+                    const charCodeEnd = data.indexOf("\\", i + 1);
+                    if(charCodeEnd === -1) {
+                        unproccessedText += "\\";
+                        continue;
+                    }
+                    const charCode = parseInt(data.slice(i + 1, charCodeEnd));
+                    if(Number.isNaN(charCode)) {
+                        unproccessedText += "\\";
+                        continue;
+                    }
+                    unproccessedText += String.fromCharCode(charCode);
+                    i = charCodeEnd;
+                }
+                else unproccessedText += currentChar;
+            }
+            resolve(unproccessedText || null);
         })
 
         boxSpawner.on('exit', () => resolve(null));
     })
 }
 
-export function displayMask(title: string, body: string, defaultText: string = ""): Promise<string | null> {
+export function displayMask(title: string, body: string, defaultText: string = "", okButtonLabel: string = "Ok", cancelButtonLabel: string = "Cancel"): Promise<string | null> {
     return new Promise(resolve => {
-        const boxSpawner = spawn("powershell", ["-ExecutionPolicy", "Bypass", "-File", path(__dirname, '../../../', 'native/win32/mask.ps1').replace("app.asar", "app.asar.unpacked"), title, body, defaultText]);
+        const inDist = __dirname.endsWith("dist") || __dirname.endsWith("dist/") || __dirname.endsWith("dist\\");
+        const rootPath = path(__dirname, inDist ? "../" : '../../../');
+        const boxSpawner = spawn("powershell", ["-ExecutionPolicy", "Bypass", "-File", path(rootPath, 'native/win32/mask.ps1').replace("app.asar", "app.asar.unpacked"), title, body, defaultText, okButtonLabel || "Ok", cancelButtonLabel || "Cancel"]);
 
         boxSpawner.stdout.on('data', (d: string) => {
-            const data = d.toString();
-            if (data.startsWith("RETURN")) resolve(data.replace("RETURN", "").trim() || null);
+            let data = d.toString();
+            if(!data.startsWith("RETURN")) return;
+            data = data.slice("RETURN".length);
+            data = data.trim();
+            let unproccessedText = "";
+            for(let i = 0;i < data.length;i++) {
+                const currentChar = data.charAt(i);
+                if(currentChar === "/" && data.charAt(i + 1) === "\\") {
+                    unproccessedText += "\\";
+                    i++;
+                }
+                else if(currentChar === "\\") {
+                    const charCodeEnd = data.indexOf("\\", i + 1);
+                    if(charCodeEnd === -1) {
+                        unproccessedText += "\\";
+                        continue;
+                    }
+                    const charCode = parseInt(data.slice(i + 1, charCodeEnd));
+                    if(Number.isNaN(charCode)) {
+                        unproccessedText += "\\";
+                        continue;
+                    }
+                    unproccessedText += String.fromCharCode(charCode);
+                    i = charCodeEnd;
+                }
+                else unproccessedText += currentChar;
+            }
+            resolve(unproccessedText || null);
         })
 
         boxSpawner.on('exit', () => resolve(null));

--- a/test.js
+++ b/test.js
@@ -1,0 +1,9 @@
+const prompt = require(".");
+
+prompt("Test Title", "Test Text", {
+  defaultText: "Default test",
+  okButtonLabel: "Submit",
+  cancelButtonLabel: "Abort"
+}).then(res => {
+  console.log(res);
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,10 @@
     "strict": false,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"],
+    "declaration": true,
+    "emitDeclarationOnly": false
   },
   "compileOnSave": true
 }


### PR DESCRIPTION
Hello, in this pull request I have made some improvements to the native-prompt package, I fixed a bug that made non ascii characters like á or ñ in windows to be a question when the string was returned and I have made a more acurate input box for windows, for it to feel more acurate to how a real input box in windows would look like.

The problem that windows input box didn't accept non ascii characters was not in the input box itself, it was a problem when the spawner recieved the string, so I made a codification for non ascii characters before passing it to the node side and then in node I decode before resolving the promise.

About the new input box, I've commented the old one because I have some problems with it. I mean, it fells more modern windows input box but it is slower to start because it has to run powershell to start, and I know a .exe would be the best option (because it would be inmediate and I can make it look like a windows input box) but at the same time it's not open source, so I'm not sure to put it in the project.

About the ok and cancel labels, in Linux when you don't set it it is not passed to the command so if it is modified by the language settings it is not affected, but in windows, as I have to set a label for the buttons, when you don't set it, it is set as Ok or Cancel.

I updated the readme.md, installed the @types/node for there no longer be type isues and created a simple test to make testing easier. they're some minor but important details.